### PR TITLE
Use fallback-x11

### DIFF
--- a/org.kde.ktuberling.json
+++ b/org.kde.ktuberling.json
@@ -8,7 +8,7 @@
     "finish-args": [
         "--share=ipc",
         "--socket=cups",
-        "--socket=x11",
+        "--socket=fallback-x11",
         "--socket=wayland",
         "--socket=pulseaudio",
         "--device=dri",


### PR DESCRIPTION
On a Wayland session, this app does not need the X11 socket.

Using fallback-x11 causes Flatpak to not expose the X11 socket on a Wayland session; and has the knock-on effect of not marking the app as “(Potentially) Unsafe” on the Flathub website and in GNOME Software.