### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.ktuberling.json
+++ b/org.kde.ktuberling.json
@@ -14,6 +14,14 @@
         "--device=dri",
         "--filesystem=xdg-config/kdeglobals:ro"
     ],
+    "cleanup": [
+        "/include",
+        "/lib/cmake",
+        "/lib/qml",
+        "/share/carddecks",
+        "/share/doc",
+        "/share/qlogging-categories6"
+    ],
     "modules": [
         {
             "name": "libkdegames",


### PR DESCRIPTION
KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.

This PR also removes the /share/carddecks folder, which is not required for this game.